### PR TITLE
Add _cmdsConfig variable to volvocars class

### DIFF
--- a/core/class/volvocars.class.php
+++ b/core/class/volvocars.class.php
@@ -22,6 +22,9 @@ require_once __DIR__ . '/../../../../core/php/core.inc.php';
 require_once __DIR__ . '/volvoAccount.class.php';
 
 class volvocars extends eqLogic {
+	/* VARIABLES DE LA CLASSE */
+	public $_cmdsConfig; 
+	
 	/*	 * *************************Attributs****************************** */
 
 	const PYTHON_PATH = __DIR__ . '/../../resources/venv/bin/python3';


### PR DESCRIPTION
Pour éviter le warning ci-dessous en PHP 8

PHP Deprecated: Creation of dynamic property volvocars::$_cmdsConfig is deprecated in /var/www/html/plugins/volvocars/core/class/volvocars.class.php on line 452